### PR TITLE
fix: expo web 빌드 에러

### DIFF
--- a/.github/workflow/expo-ci-cd.yml
+++ b/.github/workflow/expo-ci-cd.yml
@@ -54,11 +54,11 @@ jobs:
 
       - name: 🌐 Build Web Version
         if: success() && github.event_name == 'push' && github.ref == 'refs/heads/main'
-        run: npx expo build:web
+        run: npx expo export --platform web
 
       - name: 🚀 Deploy to GitHub Pages
         if: success() && github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./web-build
+          publish_dir: ./dist


### PR DESCRIPTION
- 최신 버전의 Expo CLI에서는 npx expo export --platform web을 사용하며, 이는 dist 디렉토리에 결과물을 생성한다

## 관련 이슈 번호
#24

## 변경 사항
변경된 주요 사항을 나열해주세요:
- 변경 사항 1
- 변경 사항 2

## 테스트
변경 사항이 잘 작동하는지 확인한 방법을 설명해주세요:
1. 테스트 방법 1
2. 테스트 방법 2

## 추가 정보 (선택)
추가로 필요한 정보가 있다면 작성해주세요.
