### PR TITLE
fix: 배포된 웹에 font, icon 적용 안되는 에러

### DIFF
--- a/scripts/postbuild.js
+++ b/scripts/postbuild.js
@@ -12,10 +12,42 @@ if (!indexContent.includes('<base href="/all-taxi-app/">')) {
   );
 }
 
-// 스크립트 경로 수정
-indexContent = indexContent.replace(
-  'src="/_expo/',
-  'src="/all-taxi-app/_expo/'
-);
+// 스크립트 및 에셋 경로 수정
+indexContent = indexContent.replace(/src="\//g, 'src="/all-taxi-app/');
+indexContent = indexContent.replace(/href="\//g, 'href="/all-taxi-app/');
 
 fs.writeFileSync(indexPath, indexContent);
+
+// 폰트 파일 경로 수정
+const assetsPath = path.join(__dirname, "..", "dist");
+function processDirectory(directory) {
+  fs.readdirSync(directory, { withFileTypes: true }).forEach((dirent) => {
+    const fullPath = path.join(directory, dirent.name);
+    if (dirent.isDirectory()) {
+      processDirectory(fullPath);
+    } else if (
+      dirent.isFile() &&
+      (dirent.name.endsWith(".js") || dirent.name.endsWith(".css"))
+    ) {
+      try {
+        let content = fs.readFileSync(fullPath, "utf8");
+        content = content.replace(/\/assets\//g, "/all-taxi-app/assets/");
+        content = content.replace(
+          /\/src\/all-taxi-app\/assets\//g,
+          "/src/assets/"
+        );
+
+        // 중복 경로가 생성되지 않도록 확인
+        content = content.replace(
+          /\/all-taxi-app\/all-taxi-app\//g,
+          "/all-taxi-app/"
+        );
+        fs.writeFileSync(fullPath, content);
+      } catch (err) {
+        console.error(`Error processing file ${fullPath}:`, err);
+      }
+    }
+  });
+}
+
+processDirectory(assetsPath);


### PR DESCRIPTION
assets을 불러오는 경로 수정을 위한 스크립트 작성

## 관련 이슈 번호
#28

## 변경 사항
변경된 주요 사항을 나열해주세요:
- npm run deploy 하는 경우에 생성되는 dist 폴더 내부에서 폰트, 아이콘을 불러오는 경로 수정을 위해 postbuild.js에 스크립트 작성

## 테스트
변경 사항이 잘 작동하는지 확인한 방법을 설명해주세요:
1. https://all-taxi.github.io/all-taxi-app/ 에 접속한다.
2. console을 열고 폰트와 아이콘이 잘 적용되는지 확인한다. 아래 사진과 같다면 잘 적용된 것
<img width="1269" alt="image" src="https://github.com/user-attachments/assets/9a1fb32b-d395-49c7-b26b-ee25bcba2291">


## 추가 정보 (선택)
배포된 웹에서 폰트와 아이콘과 같은 assets가 적용되지 않는 오류는 index.html 내에서 경로를 불러오는 코드가 잘못된 경우인 것 같다.
이번 에러의 경우에도 npm run deploy 이후에 생성된 dist/_expo/static/js/web/AppEntry-cc6908bf82adfb708061cc357d8299a9.js 에서 폰트를 불러오는 경로가 잘못 설정되어 있어서 404 에러가 떴다

이 프로젝트의 경우 npm run deploy 시에 
1) npx expo export -p web && node scripts/postbuild.js
2) gh-pages -t -d dist
위와 같은 순서로 명령어가 실행되는데 postbuild.js에서 이전에 설정한 경로 관련 코드가 assets를 설정하는 경로와 충돌되어서 에러가 발생했다! 

한 줄 요약: 주의해라 경로 설정!!!!!! 
